### PR TITLE
Fix movie-api Docker deployment

### DIFF
--- a/apps/movie-api/.env.example
+++ b/apps/movie-api/.env.example
@@ -1,3 +1,3 @@
-KEYCLOAK_URL=http://localhost:8081
+KEYCLOAK_URL=http://keycloak:8080
 KEYCLOAK_REALM=test
 APP_NAME=movies-backend

--- a/apps/movie-api/.env.example
+++ b/apps/movie-api/.env.example
@@ -1,0 +1,3 @@
+KEYCLOAK_URL=http://localhost:8081
+KEYCLOAK_REALM=test
+APP_NAME=movies-backend

--- a/apps/movie-api/docker-compose.yml
+++ b/apps/movie-api/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     image: sagebionetworks/challenge-registry-movie-api:latest
     container_name: challenge-registry-movie-api
     restart: always
+    env_file:
+      - .env
     ports:
       - "9000:9000"

--- a/apps/movie-api/pom.xml
+++ b/apps/movie-api/pom.xml
@@ -169,7 +169,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 		<profile>
 			<id>prod</id>
 			<activation>
-				<activeByDefault>false</activeByDefault>
+				<activeByDefault>true</activeByDefault>
 			</activation>
 			<properties>
 				<active-profiles>prod</active-profiles>
@@ -178,7 +178,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 		<profile>
 			<id>dev</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<activeByDefault>false</activeByDefault>
 			</activation>
 			<properties>
 				<active-profiles>dev</active-profiles>

--- a/apps/movie-api/project.json
+++ b/apps/movie-api/project.json
@@ -50,7 +50,7 @@
       "executor": "@nxrocks/nx-spring-boot:serve",
       "options": {
         "root": "apps/movie-api",
-        "args": []
+        "args": ["-P", "dev"]
       }
     },
     "build-image": {

--- a/apps/movie-api/project.json
+++ b/apps/movie-api/project.json
@@ -3,6 +3,13 @@
   "sourceRoot": "apps/movie-api/src",
   "projectType": "application",
   "targets": {
+    "prepare": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "command": "shx cp .env.example .env",
+        "cwd": "apps/movie-api"
+      }
+    },
     "build": {
       "executor": "@nxrocks/nx-spring-boot:build",
       "options": {

--- a/apps/movie-api/project.json
+++ b/apps/movie-api/project.json
@@ -49,7 +49,8 @@
     "serve": {
       "executor": "@nxrocks/nx-spring-boot:serve",
       "options": {
-        "root": "apps/movie-api"
+        "root": "apps/movie-api",
+        "args": []
       }
     },
     "build-image": {

--- a/apps/movie-api/src/main/resources/application-dev.yaml
+++ b/apps/movie-api/src/main/resources/application-dev.yaml
@@ -2,7 +2,7 @@ server:
   port: 9000
 
 keycloak:
-  url: http://localhost:8081
+  url: http://localhost:8082
   realm: test
 
 management:

--- a/apps/movie-api/src/main/resources/application-prod.yaml
+++ b/apps/movie-api/src/main/resources/application-prod.yaml
@@ -1,11 +1,11 @@
 server:
   port: 9000
 
-keycloak:
-  url: ${KEYCLOAK_URL}
-  realm: ${KEYCLOAK_REALM}
+# keycloak:
+#   url: ${KEYCLOAK_URL}
+#   realm: ${KEYCLOAK_REALM}
 
-management:
-  metrics:
-    tags:
-      application: ${APP_NAME}
+# management:
+#   metrics:
+#     tags:
+#       application: ${APP_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     image: sagebionetworks/challenge-registry-movie-api:latest
     container_name: challenge-registry-movie-api
     restart: always
+    env_file:
+      - ./apps/movie-api/.env
     networks:
       - challenge-registry
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     command: start-dev
     depends_on:
       - keycloak-db
+      - challenge-registry-movie-api  # cheating temporarily to make it easier to start the stack.
 
   keycloak-db:
     image: sagebionetworks/keycloak-db:latest


### PR DESCRIPTION
Fixes https://github.com/Sage-Bionetworks/challenge-registry/issues/214

## Notes

- `nx serve movie-api` reads `KEYCLOAK_URL` from `.env`.
- If the variable `KEYCLOAK_URL` is not found in `.env`, the profile value `keycloak.url` is used.

The above observations are described here: [4.3 Overwriting Configuration Values Externally](https://www.oreilly.com/library/view/quarkus-cookbook/9781492062646/ch04.html)

Assume that the variable `keycloak.jwk` is set to `${keycloak.url}/realms/${keycloak.realm}/protocol/openid-connect/certs` in `application.yml`.

- If the env var `KEYCLOAK_URL` is found in `.env`, the this value is used by `keycloak.jwk`.
- If not, the selected profile file is loaded. If the the property `keycloak.jwk` is found, then this value is used by  `keycloak.jwk`.

## Changelog

- The server now start with the `prod` profile by default.
- The command `nx serve movie-api` starts the server in development mode.
- Workspace `docker-compose.yml` can now be used to start properly `challenge-registry-movie-api`.