### PR TITLE
feat(bot): add CLI

### DIFF
--- a/apps/challenge-bot/app.yml
+++ b/apps/challenge-bot/app.yml
@@ -22,7 +22,7 @@ default_events:
   # - deployment_status
   # - fork
   # - gollum
-  # - issue_comment
+  - issue_comment
   - issues
 # - label
 # - milestone
@@ -128,7 +128,6 @@ default_permissions:
 
 # The homepage of your GitHub App.
 url: https://github.com/Sage-Bionetworks/challenge-registry
-
 # A description of the GitHub App.
 # description: A description of my awesome app
 

--- a/apps/challenge-bot/package.json
+++ b/apps/challenge-bot/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@probot/adapter-aws-lambda-serverless": "^3.0.1",
     "ajv": "^8.11.0",
+    "commander": "^9.4.1",
     "deepmerge": "^4.2.2",
     "probot": "^12.2.4",
     "serverless-http": "^3.1.0",

--- a/apps/challenge-bot/package.json
+++ b/apps/challenge-bot/package.json
@@ -31,6 +31,7 @@
     "deepmerge": "^4.2.2",
     "probot": "^12.2.4",
     "serverless-http": "^3.1.0",
+    "string-argv": "^0.3.1",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/apps/challenge-bot/src/build-challenge-app.ts
+++ b/apps/challenge-bot/src/build-challenge-app.ts
@@ -2,10 +2,11 @@ import { Context, Probot } from 'probot';
 import { ChallengeApp } from './challenge-app';
 
 export const buildChallengeApp = async (app: Probot) => {
-  app.on('issues.opened', run);
+  // app.on('issues.opened', run);
+  app.on('issue_comment.created', run);
   // app.on('pull_request.opened', processPullRequestEvent);
 
-  async function run(context: Context<'issues'>) {
+  async function run(context: Context<'issue_comment'>) {
     const challengeApp = new ChallengeApp(context);
     await challengeApp.run();
   }

--- a/apps/challenge-bot/src/challenge-app.ts
+++ b/apps/challenge-bot/src/challenge-app.ts
@@ -3,16 +3,19 @@ import pino from 'pino';
 import { version } from '../package.json';
 import { Server } from './server/server';
 import { Configuration, getConfiguration } from './config';
+import { Command } from 'commander';
+import stringArgv from 'string-argv';
 
 export const logger = pino();
 
 export class ChallengeApp {
-  private context: Context<'issues'>;
+  private context: Context<'issue_comment'>;
   private logger: pino.Logger;
   public server: Server;
   private config?: Configuration;
+  private program = new Command();
 
-  constructor(context: Context<'issues'>) {
+  constructor(context: Context<'issue_comment'>) {
     this.context = context;
     this.logger = logger.child({
       version,
@@ -22,6 +25,31 @@ export class ChallengeApp {
       // sha: this.headSha,
     });
     this.server = new Server();
+
+    this.program.name('challenge-bot');
+    this.program.exitOverride();
+    this.program.configureOutput({
+      // Visibly override write routines as example!
+      writeOut: (str) => process.stdout.write(`[OUT] ${str}`),
+      writeErr: (str) => process.stdout.write(`[ERR] ${str}`),
+      // Highlight errors in color.
+      // outputError: (str, write) => write(errorColor(str))
+    });
+    // .usage('[global options] command')
+    // .version(Pkg.version, '-v, --version', 'output the current version')
+    // .description(Pkg.description);
+
+    this.program
+      .command('ping')
+      .description('ping the bot')
+      .action(() => this.ping());
+  }
+
+  private async ping(): Promise<void> {
+    const issueComment = this.context.issue({
+      body: 'pong',
+    });
+    await this.context.octokit.issues.createComment(issueComment);
   }
 
   async run(): Promise<void> {
@@ -29,13 +57,34 @@ export class ChallengeApp {
       this.config = await getConfiguration(this.context);
       this.logger.info({ config: this.config }, 'Loaded config');
     } catch (err) {
-      this.logger.error('An error occured', err);
+      this.logger.error(
+        'An error occured while loading the configuration',
+        err
+      );
     }
 
-    const issueComment = this.context.issue({
-      body: 'Thanks for opening this issue! ' + this.config?.message,
-    });
-    await this.context.octokit.issues.createComment(issueComment);
+    // const { comment, issue, pull_request: pr } = this.context.payload;
+    // const command = (comment || issue || pr).body;
+
+    const body = this.context.payload.comment.body;
+    this.logger.info({ body }, 'body');
+    if (!!body && body.startsWith('challenge-bot')) {
+      this.logger.info({ body }, 'Received bot command');
+      const argv = stringArgv(body);
+      this.logger.info({ argv }, 'argv');
+      try {
+        await this.program.parseAsync(argv.slice(1), {
+          from: 'user',
+        });
+      } catch (err) {
+        this.logger.info({ err }, 'CLI error');
+      }
+    }
+
+    // const issueComment = this.context.issue({
+    //   body: 'Thanks for opening this issue! ' + this.config?.message,
+    // });
+    // await this.context.octokit.issues.createComment(issueComment);
   }
 
   // get repo(): string {

--- a/apps/challenge-bot/src/challenge-app.ts
+++ b/apps/challenge-bot/src/challenge-app.ts
@@ -14,6 +14,7 @@ export class ChallengeApp {
   public server: Server;
   private config?: Configuration;
   private program = new Command();
+  private description = 'Awesome bot';
 
   constructor(context: Context<'issue_comment'>) {
     this.context = context;
@@ -26,7 +27,7 @@ export class ChallengeApp {
     });
     this.server = new Server();
 
-    this.program.name('challenge-bot');
+    this.program.name('challenge-bot').description(this.description);
     this.program.exitOverride();
     this.program.configureOutput({
       // Visibly override write routines as example!
@@ -48,6 +49,11 @@ export class ChallengeApp {
       .command('version')
       .description('output the version number')
       .action(() => console.log(version));
+
+    this.program
+      .command('description')
+      .description('output the description')
+      .action(() => console.log(this.description));
   }
 
   private async ping(): Promise<void> {

--- a/apps/challenge-bot/src/challenge-app.ts
+++ b/apps/challenge-bot/src/challenge-app.ts
@@ -43,6 +43,11 @@ export class ChallengeApp {
       .command('ping')
       .description('ping the bot')
       .action(() => this.ping());
+
+    this.program
+      .command('version')
+      .description('output the version number')
+      .action(() => console.log(version));
   }
 
   private async ping(): Promise<void> {

--- a/apps/challenge-bot/src/config/get-configuration.ts
+++ b/apps/challenge-bot/src/config/get-configuration.ts
@@ -13,7 +13,7 @@ export const DEFAULT_CONFIGURATION: Configuration = {
 };
 
 export const getConfiguration = async (
-  context: Context<'issues'>
+  context: Context<'issue_comment'>
 ): Promise<Configuration> => {
   const validate = ajv.compile(configSchema);
 

--- a/apps/challenge-bot/yarn.lock
+++ b/apps/challenge-bot/yarn.lock
@@ -1040,6 +1040,7 @@ __metadata:
     serverless-http: ^3.1.0
     serverless-offline: ^11.1.3
     smee-client: 1.2.3
+    string-argv: ^0.3.1
     tslib: ^2.0.0
     typescript: 4.8.4
   languageName: unknown
@@ -6488,6 +6489,13 @@ __metadata:
     es5-ext: ^0.10.49
     is-stream: ^1.1.0
   checksum: 2a81ebfc923a3e6b50ecce63fa8b8fcb2317f7eee1065aa067b831635bb491fce88d2843f0d3221c53fa758b0cdf5f58cd97635878f09ddccf3d1e1b67471a4a
+  languageName: node
+  linkType: hard
+
+"string-argv@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "string-argv@npm:0.3.1"
+  checksum: efbd0289b599bee808ce80820dfe49c9635610715429c6b7cc50750f0437e3c2f697c81e5c390208c13b5d5d12d904a1546172a88579f6ee5cbaaaa4dc9ec5cf
   languageName: node
   linkType: hard
 

--- a/apps/challenge-bot/yarn.lock
+++ b/apps/challenge-bot/yarn.lock
@@ -1031,6 +1031,7 @@ __metadata:
     "@probot/adapter-aws-lambda-serverless": ^3.0.1
     "@types/node": 18.7.23
     ajv: ^8.11.0
+    commander: ^9.4.1
     deepmerge: ^4.2.2
     js-yaml: ^4.1.0
     nock: 13.2.9
@@ -2154,6 +2155,13 @@ __metadata:
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
   checksum: d7090410c0de6bc5c67d3ca41c41760d6d268f3c799e530aafb73b7437d1826bbf0d2a3edac33f8b57cc9887b4a986dce307fa5557e109be40eadb7c43b21742
+  languageName: node
+  linkType: hard
+
+"commander@npm:^9.4.1":
+  version: 9.4.1
+  resolution: "commander@npm:9.4.1"
+  checksum: bfb18e325a5bdf772763c2213d5c7d9e77144d944124e988bcd8e5e65fb6d45d5d4e86b09155d0f2556c9a59c31e428720e57968bcd050b2306e910a0bf3cf13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Enables the user to interact with the bot by entering commands in GH comments.

For example: `/challenge-bot version`

## TODO

- [x] Specify bot version to commander.
- [x] Specify bot description to commander.
- [ ] Commander should display out log as comment.
- [ ] Commander should display err log as comment.
- [ ] Format CLI output with a template.
- [ ] Refactor CLI code to keep main app lean.

## References

- https://probot.github.io/docs/extensions/#commands
  - https://github.com/probot/commands
  - Small extension that can be replaced with own code.